### PR TITLE
Add package to access Github Issues API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.8
 
 ADD . /go/src/github.com/m-lab/alertmanager-github-receiver
 
+# TODO(soltesz): vendor dependencies.
 RUN go get -v github.com/m-lab/alertmanager-github-receiver/cmd/github_receiver
 
 # RUN go install -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.8
+
+ADD . /go/src/github.com/m-lab/alertmanager-github-receiver
+
+RUN go get -v github.com/m-lab/alertmanager-github-receiver/cmd/github_receiver
+
+# RUN go install -v
+ENTRYPOINT ["/go/bin/github_receiver"]

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -1,0 +1,124 @@
+// Copyright 2017 alertmanager-github-receiver Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+// A client interface around the GitHub API for creating, listing, and closing
+// issues.
+package issues
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/google/go-github/github"
+	"github.com/kr/pretty"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+)
+
+// A Client manages communication with the GitHub API.
+type Client struct {
+	// githubClient is an authenticated client for accessing the github API.
+	GithubClient *github.Client
+	// owner is the github project (e.g. github.com/<owner>/<repo>).
+	owner string
+	// repo is the github repository under the above owner.
+	repo string
+}
+
+// NewClient creates an Client authenticated using the GitHub authToken.
+// Future operations are only performed on the given github "owner/repo".
+func NewClient(owner, repo, authToken string) (*Client, error) {
+	if authToken == "" {
+		return nil, fmt.Errorf("Authentication Token must not be empty.")
+	}
+	ctx := context.Background()
+	tokenSource := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: authToken},
+	)
+	client := &Client{
+		GithubClient: github.NewClient(oauth2.NewClient(ctx, tokenSource)),
+		owner:        owner,
+		repo:         repo,
+	}
+	return client, nil
+}
+
+// CreateIssue creates a new GitHub issue. New issues are unassigned.
+func (c *Client) CreateIssue(title, body string) (*github.Issue, error) {
+	// Construct a minimal github issue request.
+	issueReq := github.IssueRequest{
+		Title: &title,
+		Body:  &body,
+	}
+
+	// Create the issue.
+	// See also: https://developer.github.com/v3/issues/#create-an-issue
+	// See also: https://godoc.org/github.com/google/go-github/github#IssuesService.Create
+	issue, resp, err := c.GithubClient.Issues.Create(
+		context.Background(), c.owner, c.repo, &issueReq)
+	if err != nil {
+		log.Printf("Error in CreateIssue: response: %v\n%s",
+			err, pretty.Sprint(resp))
+		return nil, err
+	}
+	return issue, nil
+}
+
+// ListOpenIssues returns open issues from github Github issues are either
+// "open" or "closed". Closed issues have either been resolved automatically or
+// by a person. So, there will be an ever increasing number of "closed" issues.
+// By only listing "open" issues we limit the number of issues returned.
+func (c *Client) ListOpenIssues() ([]*github.Issue, error) {
+	var allIssues []*github.Issue
+
+	opts := &github.IssueListByRepoOptions{State: "open"}
+	for {
+		issues, resp, err := c.GithubClient.Issues.ListByRepo(
+			context.Background(), c.owner, c.repo, opts)
+		if err != nil {
+			log.Printf("Failed to list open github issues: %v\n%s",
+				err, pretty.Sprint(resp))
+			return nil, err
+		}
+		// Collect 'em all.
+		allIssues = append(allIssues, issues...)
+
+		// Continue loading the next page until all issues are received.
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.ListOptions.Page = resp.NextPage
+	}
+	return allIssues, nil
+}
+
+// CloseIssue changes the issue state to "closed" unconditionally. If the issue
+// is already close, then this should have no effect.
+func (c *Client) CloseIssue(issue *github.Issue) (*github.Issue, error) {
+	issueReq := github.IssueRequest{
+		State: github.String("closed"),
+	}
+
+	// Edits the issue to have "closed" state.
+	// See also: https://developer.github.com/v3/issues/#edit-an-issue
+	// See also: https://godoc.org/github.com/google/go-github/github#IssuesService.Edit
+	closedIssue, resp, err := c.GithubClient.Issues.Edit(
+		context.Background(), c.owner, c.repo, *issue.Number, &issueReq)
+	if err != nil {
+		log.Printf("Failed to close issue: %v\n%s", err, pretty.Sprint(resp))
+		return nil, err
+	}
+	return closedIssue, nil
+}

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -13,8 +13,8 @@
 // limitations under the License.
 //////////////////////////////////////////////////////////////////////////////
 
-// A client interface around the Github API for creating, listing, and closing
-// issues.
+// A client interface wrapping the Github API for creating, listing, and closing
+// issues on a single repository.
 package issues
 
 import (

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //////////////////////////////////////////////////////////////////////////////
 
-// A client interface around the GitHub API for creating, listing, and closing
+// A client interface around the Github API for creating, listing, and closing
 // issues.
 package issues
 
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// A Client manages communication with the GitHub API.
+// A Client manages communication with the Github API.
 type Client struct {
 	// githubClient is an authenticated client for accessing the github API.
 	GithubClient *github.Client
@@ -37,7 +37,7 @@ type Client struct {
 	repo string
 }
 
-// NewClient creates an Client authenticated using the GitHub authToken.
+// NewClient creates an Client authenticated using the Github authToken.
 // Future operations are only performed on the given github "owner/repo".
 func NewClient(owner, repo, authToken string) (*Client, error) {
 	if authToken == "" {
@@ -55,7 +55,7 @@ func NewClient(owner, repo, authToken string) (*Client, error) {
 	return client, nil
 }
 
-// CreateIssue creates a new GitHub issue. New issues are unassigned.
+// CreateIssue creates a new Github issue. New issues are unassigned.
 func (c *Client) CreateIssue(title, body string) (*github.Issue, error) {
 	// Construct a minimal github issue request.
 	issueReq := github.IssueRequest{

--- a/issues/issues_test.go
+++ b/issues/issues_test.go
@@ -1,0 +1,84 @@
+package issues_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-github/github"
+	"src/github.com/stephen-soltesz/alertmanager-github-receiver/issues"
+)
+
+// Adapted from https://github.com/google/go-github/blob/master/github/github_test.go#L39
+
+// Global vars for tests.
+//
+// Tests should register handlers on mux which provide mock responses for the
+// API method being tested.
+var (
+	// mux is the HTTP request multiplexer used with the test server.
+	mux *http.ServeMux
+
+	// server is a test HTTP server used to provide mock API responses.
+	server *httptest.Server
+)
+
+func setup(client *issues.Client) {
+	// test server
+	mux = http.NewServeMux()
+	server = httptest.NewServer(mux)
+
+	url, _ := url.Parse(server.URL)
+	client.GithubClient.BaseURL = url
+
+	// github client configured to use test server
+	// client = NewClient(nil)
+	// client.BaseURL = url
+	// client.UploadURL = url
+}
+
+func teardown() {
+	server.Close()
+}
+
+func TestCreateIssue(t *testing.T) {
+	client, err := issues.NewClient("owner", "repo", "fake-auth-token")
+	if err != nil {
+		t.Fatal("Failed to create new client.")
+	}
+	setup(client)
+	defer teardown()
+
+	title := "my title"
+	body := "my issue body"
+
+	mux.HandleFunc("/repos/owner/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		v := &github.IssueRequest{}
+		json.NewDecoder(r.Body).Decode(v)
+
+		if *v.Title != title {
+			t.Errorf("Request title = %+v, want %+v", *v.Title, title)
+		}
+		if *v.Body != body {
+			t.Errorf("Request body = %+v, want %+v", *v.Body, body)
+		}
+
+		// Fake result.
+		fmt.Fprint(w, `{"number":1}`)
+	})
+
+	issue, err := client.CreateIssue(title, body)
+	if err != nil {
+		t.Errorf("Issues.Create returned error: %v", err)
+	}
+
+	want := &github.Issue{Number: github.Int(1)}
+	if !reflect.DeepEqual(issue, want) {
+		t.Errorf("Issues.Create returned %+v, want %+v", issue, want)
+	}
+
+}

--- a/issues/issues_test.go
+++ b/issues/issues_test.go
@@ -17,12 +17,14 @@ package issues_test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/kr/pretty"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/kr/pretty"
 
 	"github.com/google/go-github/github"
 	"github.com/stephen-soltesz/alertmanager-github-receiver/issues"
@@ -71,6 +73,11 @@ func TestCreateIssue(t *testing.T) {
 	testMux.HandleFunc("/repos/owner/repo/issues", func(w http.ResponseWriter, r *http.Request) {
 		v := &github.IssueRequest{}
 		json.NewDecoder(r.Body).Decode(v)
+
+		authToken := r.Header.Get("Authorization")
+		if !strings.Contains(authToken, "FAKE-AUTH-TOKEN") {
+			t.Errorf("Request does not contain bearer token")
+		}
 
 		if *v.Title != title {
 			t.Errorf("Request title = %+v, want %+v", *v.Title, title)


### PR DESCRIPTION
This PR is a preliminary package for managing issues via the Github API.

The alertmanager-github-receiver will have an event loop that receives alerts from alertmanager and syncs the alert with Github (closing issues that are no longer firing and creating issues that are not yet open).

Github API documentation: https://developer.github.com/v3/
Github Go client: https://github.com/google/go-github

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/alertmanager-github-receiver/1)
<!-- Reviewable:end -->
