### PR TITLE
Add simple issue handler & github_receiver command

### DIFF
--- a/cmd/github_receiver/main.go
+++ b/cmd/github_receiver/main.go
@@ -1,0 +1,67 @@
+// Copyright 2017 alertmanager-github-receiver Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+// github_receiver accepts Alertmanager webhook notifications and creates or
+// closes corresponding issues on Github.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/stephen-soltesz/alertmanager-github-receiver/issues"
+)
+
+var (
+	authtoken   = flag.String("authtoken", "", "Oauth2 token for access to github API.")
+	githubOwner = flag.String("owner", "", "The github user or organization name.")
+	githubRepo  = flag.String("repo", "", "The repository where issues are created.")
+)
+
+const (
+	usage = `
+Usage of %s:
+
+Github receiver requires a github --authtoken and target github --owner and
+--repo names.
+
+`
+)
+
+func init() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, usage, os.Args[0])
+		flag.PrintDefaults()
+	}
+}
+
+func serveListener(client *issues.Client) {
+	http.Handle("/", &issues.ListHandler{client})
+	// TODO: enable alert receiver.
+	// http.Handle("/v1/receiver", &alerts.ReceiverHandler{client})
+	http.ListenAndServe(":9393", nil)
+}
+
+func main() {
+	flag.Parse()
+	if *authtoken == "" || *githubOwner == "" || *githubRepo == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+	client := issues.NewClient(*githubOwner, *githubRepo, *authtoken)
+	serveListener(client)
+}

--- a/issues/handler.go
+++ b/issues/handler.go
@@ -1,0 +1,63 @@
+// Copyright 2017 alertmanager-github-receiver Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+package issues
+
+import (
+	"fmt"
+	"github.com/google/go-github/github"
+	"html/template"
+	"net/http"
+)
+
+const (
+	listRawHTMLTemplate = `
+<html><body>
+<h1>Open Issues</h1>
+<table>
+  {{range .}}
+	<tr><td><a href={{.HTMLURL}}>{{.Title}}</a></td></tr>
+  {{end}}
+</table>
+</body></html>`
+)
+
+var (
+	listTemplate = template.Must(template.New("list").Parse(listRawHTMLTemplate))
+)
+
+type ListClient interface {
+	ListOpenIssues() ([]*github.Issue, error)
+}
+
+type ListHandler struct {
+	Client ListClient
+}
+
+// ServeHTTP lists open issues from github for view in a browser.
+func (lh *ListHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	issues, err := lh.Client.ListOpenIssues()
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(rw, "%s\n", err)
+		return
+	}
+	err = listTemplate.Execute(rw, &issues)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(rw, "%s\n", err)
+		return
+	}
+}

--- a/issues/handler_test.go
+++ b/issues/handler_test.go
@@ -1,0 +1,74 @@
+// Copyright 2017 alertmanager-github-receiver Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+package issues_test
+
+import (
+	"github.com/google/go-github/github"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephen-soltesz/alertmanager-github-receiver/issues"
+)
+
+type fakeClient struct {
+	issues []*github.Issue
+}
+
+func (f *fakeClient) ListOpenIssues() ([]*github.Issue, error) {
+	return f.issues, nil
+}
+
+func TestListHandler(t *testing.T) {
+	expected := `
+<html><body>
+<h1>Open Issues</h1>
+<table>
+  
+	<tr><td><a href=http://foo.bar>issue1 title</a></td></tr>
+  
+</table>
+</body></html>`
+	f := &fakeClient{
+		[]*github.Issue{
+			&github.Issue{
+				HTMLURL: github.String("http://foo.bar"),
+				Title:   github.String("issue1 title"),
+			},
+		},
+	}
+	// Create a response recorder.
+	rw := httptest.NewRecorder()
+	// Create a synthetic request object for ServeHTTP.
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the list handler.
+	handler := issues.ListHandler{f}
+	handler.ServeHTTP(rw, req)
+	resp := rw.Result()
+
+	// Check the results.
+	body, _ := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("ListHandler got %d; want %d", resp.StatusCode, http.StatusOK)
+	}
+	if expected != string(body) {
+		t.Errorf("ListHandler got %q; want %q", string(body), expected)
+	}
+}

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -18,7 +18,6 @@
 package issues
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/google/go-github/github"
@@ -39,10 +38,7 @@ type Client struct {
 
 // NewClient creates an Client authenticated using the Github authToken.
 // Future operations are only performed on the given github "owner/repo".
-func NewClient(owner, repo, authToken string) (*Client, error) {
-	if authToken == "" {
-		return nil, fmt.Errorf("Authentication Token must not be empty.")
-	}
+func NewClient(owner, repo, authToken string) *Client {
 	ctx := context.Background()
 	tokenSource := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: authToken},
@@ -52,7 +48,7 @@ func NewClient(owner, repo, authToken string) (*Client, error) {
 		owner:        owner,
 		repo:         repo,
 	}
-	return client, nil
+	return client
 }
 
 // CreateIssue creates a new Github issue. New issues are unassigned.

--- a/issues/issues_test.go
+++ b/issues/issues_test.go
@@ -60,10 +60,7 @@ func teardownServer() {
 }
 
 func TestCreateIssue(t *testing.T) {
-	client, err := issues.NewClient("owner", "repo", "FAKE-AUTH-TOKEN")
-	if err != nil {
-		t.Fatal("Failed to create new client.")
-	}
+	client := issues.NewClient("owner", "repo", "FAKE-AUTH-TOKEN")
 	client.GithubClient.BaseURL = setupServer()
 	defer teardownServer()
 
@@ -102,10 +99,7 @@ func TestCreateIssue(t *testing.T) {
 }
 
 func TestListOpenIssues(t *testing.T) {
-	client, err := issues.NewClient("owner", "repo", "FAKE-AUTH-TOKEN")
-	if err != nil {
-		t.Fatal("Failed to create new client.")
-	}
+	client := issues.NewClient("owner", "repo", "FAKE-AUTH-TOKEN")
 	client.GithubClient.BaseURL = setupServer()
 	defer teardownServer()
 
@@ -131,10 +125,7 @@ func TestListOpenIssues(t *testing.T) {
 }
 
 func TestCloseIssue(t *testing.T) {
-	client, err := issues.NewClient("owner", "repo", "FAKE-AUTH-TOKEN")
-	if err != nil {
-		t.Fatal("Failed to create new client.")
-	}
+	client := issues.NewClient("owner", "repo", "FAKE-AUTH-TOKEN")
 	client.GithubClient.BaseURL = setupServer()
 	defer teardownServer()
 


### PR DESCRIPTION
This PR adds minimal functionality for the `github_receiver` command and provides a simple handler for listing currently open github issues on the target repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/alertmanager-github-receiver/2)
<!-- Reviewable:end -->
