### PR TITLE
Add -enable-auto-close option to github-receiver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,20 @@ language: go
 go:
  - 1.8.1
 
+before_install:
+  # Coverage tools
+  - go get github.com/mattn/goveralls
+  - go get github.com/wadey/gocovmerge
+
 # Unconditionally place the repo at GOPATH/src/${go_import_path} to support
 # forks.
 go_import_path: github.com/m-lab/alertmanager-github-receiver
 
 script:
-# Run query "unit tests".
-- go test -v github.com/m-lab/alertmanager-github-receiver/...
+# Run unit tests.
+- go test -covermode=count -coverprofile=alerts.cov -v github.com/m-lab/alertmanager-github-receiver/alerts
+- go test -covermode=count -coverprofile=issues.cov -v github.com/m-lab/alertmanager-github-receiver/issues
+
+# Coveralls
+- $HOME/gopath/bin/gocovmerge alerts.cov issues.cov > merge.cov
+- $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci

--- a/alerts/handler_test.go
+++ b/alerts/handler_test.go
@@ -18,16 +18,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-github/github"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/google/go-github/github"
+
+	"github.com/m-lab/alertmanager-github-receiver/alerts"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
-	"github.com/m-lab/alertmanager-github-receiver/alerts"
 )
 
 type fakeClient struct {
@@ -109,7 +110,7 @@ func TestReceiverHandler(t *testing.T) {
 			createIssue("DiskRunningFull", "body1"),
 		},
 	}
-	handler := alerts.ReceiverHandler{f}
+	handler := alerts.ReceiverHandler{f, true}
 	handler.ServeHTTP(rw, req)
 	resp := rw.Result()
 
@@ -142,7 +143,7 @@ func TestReceiverHandler(t *testing.T) {
 
 	// No pre-existing issues to close.
 	f = &fakeClient{}
-	handler = alerts.ReceiverHandler{f}
+	handler = alerts.ReceiverHandler{f, true}
 	handler.ServeHTTP(rw, req)
 	resp = rw.Result()
 

--- a/cmd/github_receiver/main.go
+++ b/cmd/github_receiver/main.go
@@ -20,16 +20,18 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/m-lab/alertmanager-github-receiver/alerts"
-	"github.com/m-lab/alertmanager-github-receiver/issues"
 	"net/http"
 	"os"
+
+	"github.com/m-lab/alertmanager-github-receiver/alerts"
+	"github.com/m-lab/alertmanager-github-receiver/issues"
 )
 
 var (
-	authtoken   = flag.String("authtoken", "", "Oauth2 token for access to github API.")
-	githubOwner = flag.String("owner", "", "The github user or organization name.")
-	githubRepo  = flag.String("repo", "", "The repository where issues are created.")
+	authtoken       = flag.String("authtoken", "", "Oauth2 token for access to github API.")
+	githubOwner     = flag.String("owner", "", "The github user or organization name.")
+	githubRepo      = flag.String("repo", "", "The repository where issues are created.")
+	enableAutoClose = flag.Bool("enable-auto-close", false, "Once an alert stops firing, automatically close open issues.")
 )
 
 const (
@@ -51,7 +53,7 @@ func init() {
 
 func serveListener(client *issues.Client) {
 	http.Handle("/", &issues.ListHandler{client})
-	http.Handle("/v1/receiver", &alerts.ReceiverHandler{client})
+	http.Handle("/v1/receiver", &alerts.ReceiverHandler{client, *enableAutoClose})
 	http.ListenAndServe(":9393", nil)
 }
 

--- a/issues/issues_test.go
+++ b/issues/issues_test.go
@@ -49,8 +49,9 @@ func setupServer() *url.URL {
 	testMux = http.NewServeMux()
 	testServer = httptest.NewServer(testMux)
 
-	// test server URL is guaranteed to parse successfully.
-	url, _ := url.Parse(testServer.URL)
+	// Test server URL is guaranteed to parse successfully.
+	// The github client library requires that the URL end with a slash.
+	url, _ := url.Parse(testServer.URL + "/")
 	return url
 }
 


### PR DESCRIPTION
This change adds a new flag to the github receiver command and changes default behavior so resolved alerts do not auto-close issues.

Previously, issues were closed automatically when the alert was resolved. With this change, issues opened by alerts are left open. This change encourages an explicit follow-up and resolution by a person, whether that be to 1) fix the alert, 2) fix a system, or 3) fix a process around a system.

The flag provides the option of continuing to auto-closing alerts, if desired.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/alertmanager-github-receiver/9)
<!-- Reviewable:end -->
