### PR TITLE
Add native metrics to github receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Because this access token has permission to create issues and operate on
 repositories the access token user can access, protect the access token as
 you would a password.
 
-## Start GitHub Reciever
+## Start GitHub Receiver
 
-To start the github reciever locally:
+To start the github receiver locally:
 ```
 docker run -it measurementlab/alertmanager-github-receiver:latest
         -authtoken=$(GITHUB_AUTH_TOKEN) -org=<org> -repo=<repo>
@@ -73,3 +73,4 @@ msg='{
 }'
 curl -XPOST --data-binary "${msg}" http://localhost:9393/v1/receiver
 ```
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,75 @@
 # alertmanager-github-receiver
-Prometheus Alertmanager webhook receiver that creates GitHub issues from alerts
+
+Not all alerts are an emergency. But, we want to track every one
+because alerts are always an actual problem. Either:
+
+ * an actual problem in the monitored system
+ * an actual problem in processes around the monitored system
+ * an actual problem with the alert itself
+
+The alertmanager github receiver creates GitHub issues using
+[Alertmanager](https://github.com/prometheus/alertmanager) webhook
+notifications.
+
+# Setup
+
+## Create GitHub access token
+
+The github receiver uses user access tokens to create issues in an existing
+repository.
+
+Generate a new access token:
+
+* Log into GitHub and visit https://github.com/settings/tokens
+* Click the 'Generate new token' button
+* Select the 'repo' scope and all subscopes of 'repo'
+
+Because this access token has permission to create issues and operate on
+repositories the access token user can access, protect the access token as
+you would a password.
+
+## Start GitHub Reciever
+
+To start the github reciever locally:
+```
+docker run -it measurementlab/alertmanager-github-receiver:latest
+        -authtoken=$(GITHUB_AUTH_TOKEN) -org=<org> -repo=<repo>
+```
+
+Note: both the org and repo must already exist.
+
+## Configure Alertmanager Webhook Plugin
+
+The Prometheus Alertmanager supports third-party notification mechanisms
+using the [Alertmanager Webhook API](https://prometheus.io/docs/alerting/configuration/#webhook_config).
+
+Add a receiver definition to the alertmanager configuration.
+
+```
+- name: 'github-receiver-issues'
+  webhook_configs:
+  - url: 'http://localhost:9393/v1/receiver'
+```
+
+To publish a test notification by hand, try:
+
+```
+msg='{
+  "version": "4",
+  "groupKey": "fakegroupkey",
+  "status": "firing",
+  "receiver": "http://localhost:9393/v1/receiver",
+  "groupLabels": {"alertname": "FoobarIsBroken"},
+  "externalURL": "http://localhost:9093",
+  "alerts": [
+    {
+      "labels": {"thing": "value"},
+      "annotations": {"hint": "how to fix foobar"},
+      "status": "firing",
+      "startsAt": "2018-06-12T01:00:00Z",
+      "endsAt": "2018-06-14T01:00:00Z"
+    }
+  ]
+}'
+curl -XPOST --data-binary "${msg}" http://localhost:9393/v1/receiver
+```

--- a/issues/handler.go
+++ b/issues/handler.go
@@ -51,6 +51,10 @@ type ListHandler struct {
 
 // ServeHTTP lists open issues from github for view in a browser.
 func (lh *ListHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if req.URL.Path != "/" && req.Method != http.MethodGet {
+		http.NotFound(rw, req)
+		return
+	}
 	issues, err := lh.ListOpenIssues()
 	if err != nil {
 		rw.WriteHeader(http.StatusInternalServerError)

--- a/issues/handler.go
+++ b/issues/handler.go
@@ -26,12 +26,14 @@ import (
 const (
 	listRawHTMLTemplate = `
 <html><body>
-<h1>Open Issues</h1>
+<h2>Open Issues</h2>
 <table>
 {{range .}}
   <tr><td><a href={{.HTMLURL}}>{{.Title}}</a></td></tr>
 {{end}}
 </table>
+<br/>
+Receiver metrics: <a href="/metrics">/metrics</a>
 </body></html>`
 )
 
@@ -51,7 +53,7 @@ type ListHandler struct {
 
 // ServeHTTP lists open issues from github for view in a browser.
 func (lh *ListHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	if req.URL.Path != "/" && req.Method != http.MethodGet {
+	if req.URL.Path != "/" || req.Method != http.MethodGet {
 		http.NotFound(rw, req)
 		return
 	}

--- a/issues/handler_test.go
+++ b/issues/handler_test.go
@@ -36,12 +36,14 @@ func (f *fakeClient) ListOpenIssues() ([]*github.Issue, error) {
 func TestListHandler(t *testing.T) {
 	expected := `
 <html><body>
-<h1>Open Issues</h1>
+<h2>Open Issues</h2>
 <table>
 
   <tr><td><a href=http://foo.bar>issue1 title</a></td></tr>
 
 </table>
+<br/>
+Receiver metrics: <a href="/metrics">/metrics</a>
 </body></html>`
 	f := &fakeClient{
 		[]*github.Issue{

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -154,8 +154,6 @@ func (c *Client) ListOpenIssues() ([]*github.Issue, error) {
 			log.Printf("Failed to list open github issues: %v\n", err)
 			return nil, err
 		}
-		fmt.Println("LISTING OPTIONS")
-		log.Println(resp.Rate)
 		// Collect 'em all.
 		for i := range issues.Issues {
 			log.Println("ListOpenIssues:", issues.Issues[i].GetTitle())


### PR DESCRIPTION
This change updates the README to describe basic setup and usage of the github receiver.

As well, this change adds native metric to the github receiver so that we can detect when API limits are exceeded, or issues that should be created fail to be created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/alertmanager-github-receiver/11)
<!-- Reviewable:end -->
