### PR TITLE
Support adding extra labels to issues

### DIFF
--- a/alerts/handler.go
+++ b/alerts/handler.go
@@ -30,7 +30,7 @@ import (
 // ReceiverClient defines all issue operations needed by the ReceiverHandler.
 type ReceiverClient interface {
 	CloseIssue(issue *github.Issue) (*github.Issue, error)
-	CreateIssue(repo, title, body string) (*github.Issue, error)
+	CreateIssue(repo, title, body string, extra []string) (*github.Issue, error)
 	ListOpenIssues() ([]*github.Issue, error)
 }
 
@@ -47,6 +47,9 @@ type ReceiverHandler struct {
 	// DefaultRepo is the repository where all alerts without a "repo" label will
 	// be created. Repo must exist.
 	DefaultRepo string
+
+	// ExtraLabels values will be added to new issues as additional labels.
+	ExtraLabels []string
 }
 
 // ServeHTTP receives and processes alertmanager notifications. If the alert
@@ -115,7 +118,7 @@ func (rh *ReceiverHandler) processAlert(msg *notify.WebhookMessage) error {
 	// issue from github, so create a new issue.
 	if msg.Data.Status == "firing" && foundIssue == nil {
 		msgBody := formatIssueBody(msg)
-		_, err := rh.Client.CreateIssue(rh.getTargetRepo(msg), msgTitle, msgBody)
+		_, err := rh.Client.CreateIssue(rh.getTargetRepo(msg), msgTitle, msgBody, rh.ExtraLabels)
 		return err
 	}
 

--- a/alerts/handler_test.go
+++ b/alerts/handler_test.go
@@ -42,7 +42,7 @@ func (f *fakeClient) ListOpenIssues() ([]*github.Issue, error) {
 	return f.listIssues, nil
 }
 
-func (f *fakeClient) CreateIssue(repo, title, body string) (*github.Issue, error) {
+func (f *fakeClient) CreateIssue(repo, title, body string, extra []string) (*github.Issue, error) {
 	fmt.Println("create issue")
 	f.createdIssue = createIssue(title, body)
 	return f.createdIssue, nil

--- a/cmd/github_receiver/main.go
+++ b/cmd/github_receiver/main.go
@@ -18,7 +18,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"net/http"
@@ -29,6 +28,7 @@ import (
 	"github.com/m-lab/alertmanager-github-receiver/issues/local"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	flag "github.com/spf13/pflag"
 )
 
 var (
@@ -38,6 +38,7 @@ var (
 	enableAutoClose = flag.Bool("enable-auto-close", false, "Once an alert stops firing, automatically close open issues.")
 	enableInMemory  = flag.Bool("enable-inmemory", false, "Perform all operations in memory, without using github API.")
 	receiverPort    = flag.String("port", "9393", "The port for accepting alertmanager webhook messages.")
+	extraLabels     = flag.StringArray("label", nil, "Extra labels to add to issues at creation time.")
 )
 
 // Metrics.
@@ -73,6 +74,7 @@ func serveReceiverHandler(client alerts.ReceiverClient) {
 		Client:      client,
 		DefaultRepo: *githubRepo,
 		AutoClose:   *enableAutoClose,
+		ExtraLabels: *extraLabels,
 	}
 	http.Handle("/", &issues.ListHandler{ListClient: client})
 	http.Handle("/v1/receiver", promhttp.InstrumentHandlerDuration(receiverDuration, receiverHandler))

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -103,12 +103,17 @@ func NewClient(org, authToken string) *Client {
 // CreateIssue creates a new Github issue. New issues are unassigned. Issues are
 // labeled with with an alert named "alert:boom:". Labels are created automatically
 // if they do not already exist in a repo.
-func (c *Client) CreateIssue(repo, title, body string) (*github.Issue, error) {
+func (c *Client) CreateIssue(repo, title, body string, extra []string) (*github.Issue, error) {
+	labels := make([]string, len(extra)+1)
+	labels[0] = "alert:boom:"
+	for i := range extra {
+		labels[i+1] = extra[i]
+	}
 	// Construct a minimal github issue request.
 	issueReq := github.IssueRequest{
 		Title:  &title,
 		Body:   &body,
-		Labels: &([]string{"alert:boom:"}), // Search using: label:"alert:boom:"
+		Labels: &labels, // Search using: label:"alert:boom:"
 	}
 
 	// Enforce a timeout on the issue creation.

--- a/issues/issues_test.go
+++ b/issues/issues_test.go
@@ -86,7 +86,7 @@ func TestCreateIssue(t *testing.T) {
 		fmt.Fprint(w, `{"number":1}`)
 	})
 
-	issue, err := client.CreateIssue("fake-repo", title, body)
+	issue, err := client.CreateIssue("fake-repo", title, body, nil)
 	if err != nil {
 		t.Errorf("CreateIssue returned error: %v", err)
 	}

--- a/issues/local/local.go
+++ b/issues/local/local.go
@@ -36,7 +36,7 @@ func NewClient() *Client {
 }
 
 // CreateIssue adds a new issue to the in memory store.
-func (c *Client) CreateIssue(repo, title, body string) (*github.Issue, error) {
+func (c *Client) CreateIssue(repo, title, body string, extra []string) (*github.Issue, error) {
 	c.issues[title] = &github.Issue{
 		Title: &title,
 		Body:  &body,

--- a/issues/local/local_test.go
+++ b/issues/local/local_test.go
@@ -38,7 +38,7 @@ func TestMemoryClient(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewClient()
-			got, err := c.CreateIssue("fake-repo", tt.title, tt.body)
+			got, err := c.CreateIssue("fake-repo", tt.title, tt.body, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Client.CreateIssue() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
To facilitate integration with other systems like waffle.io and help discover new alerts right away, this change adds the ability to specify additional label values to assign to new issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/alertmanager-github-receiver/15)
<!-- Reviewable:end -->
