### PR TITLE
Allows users to change the default label

### DIFF
--- a/cmd/github_receiver/main.go
+++ b/cmd/github_receiver/main.go
@@ -40,6 +40,7 @@ var (
 	enableAutoClose = flag.Bool("enable-auto-close", false, "Once an alert stops firing, automatically close open issues.")
 	enableInMemory  = flag.Bool("enable-inmemory", false, "Perform all operations in memory, without using github API.")
 	receiverPort    = flag.String("port", "9393", "The port for accepting alertmanager webhook messages.")
+	alertLabel      = flag.String("alertlabel", "alert:boom:", "The default label applied to all alerts")
 	extraLabels     = flag.StringArray("label", nil, "Extra labels to add to issues at creation time.")
 )
 
@@ -106,7 +107,7 @@ func main() {
 	if *enableInMemory {
 		client = local.NewClient()
 	} else {
-		client = issues.NewClient(*githubOrg, token)
+		client = issues.NewClient(*githubOrg, token, *alertLabel)
 	}
 	serveReceiverHandler(client)
 }

--- a/cmd/github_receiver/main.go
+++ b/cmd/github_receiver/main.go
@@ -40,7 +40,7 @@ var (
 	enableAutoClose = flag.Bool("enable-auto-close", false, "Once an alert stops firing, automatically close open issues.")
 	enableInMemory  = flag.Bool("enable-inmemory", false, "Perform all operations in memory, without using github API.")
 	receiverPort    = flag.String("port", "9393", "The port for accepting alertmanager webhook messages.")
-	alertLabel      = flag.String("alertlabel", "alert:boom:", "The default label applied to all alerts")
+	alertLabel      = flag.String("alertlabel", "alert:boom:", "The default label applied to all alerts. Also used to search the repo to discover exisitng alerts.")
 	extraLabels     = flag.StringArray("label", nil, "Extra labels to add to issues at creation time.")
 )
 

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -84,7 +84,8 @@ type Client struct {
 	GithubClient *github.Client
 	// org is the github user or organization name (e.g. github.com/<org>/<repo>).
 	org string
-	// alertLabel is the label applied to all alerts.
+	// alertLabel is the label applied to all alerts.  It is also used as
+	// the label to search to discover all existing alerts.
 	alertLabel string
 }
 

--- a/issues/issues_test.go
+++ b/issues/issues_test.go
@@ -59,7 +59,7 @@ func teardownServer() {
 }
 
 func TestCreateIssue(t *testing.T) {
-	client := issues.NewClient("fake-owner", "FAKE-AUTH-TOKEN")
+	client := issues.NewClient("fake-owner", "FAKE-AUTH-TOKEN", "alert:boom:")
 	client.GithubClient.BaseURL = setupServer()
 	defer teardownServer()
 
@@ -98,7 +98,7 @@ func TestCreateIssue(t *testing.T) {
 }
 
 func TestListOpenIssues(t *testing.T) {
-	client := issues.NewClient("owner", "FAKE-AUTH-TOKEN")
+	client := issues.NewClient("owner", "FAKE-AUTH-TOKEN", "alert:boom:")
 	// Override public github API with local server.
 	client.GithubClient.BaseURL = setupServer()
 	defer teardownServer()
@@ -125,7 +125,7 @@ func TestListOpenIssues(t *testing.T) {
 }
 
 func TestCloseIssue(t *testing.T) {
-	client := issues.NewClient("owner", "FAKE-AUTH-TOKEN")
+	client := issues.NewClient("owner", "FAKE-AUTH-TOKEN", "alert:boom:")
 	client.GithubClient.BaseURL = setupServer()
 	defer teardownServer()
 


### PR DESCRIPTION
Some people are restricted by their orgs to need something other than "alert:boom:"

Fixes #20

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/alertmanager-github-receiver/21)
<!-- Reviewable:end -->
