### PR TITLE
adding project assignment via project cards and custom labels

### DIFF
--- a/alerts/handler.go
+++ b/alerts/handler.go
@@ -243,8 +243,9 @@ func (rh *ReceiverHandler) getTargetRepo(msg *webhook.Message) string {
 	return rh.DefaultRepo
 }
 
-// extractLabels transforms a KV pair named "github-labels" from the alert's annotations
-// and returns them as a slice of github.Labels
+// parseAdditionalGithubInfo parses out two additional annotation keys: "github-labels"
+// and "github-project-column-id" which can be used to add more labels to a new issue,
+// and also assign the new issue to a specific project board
 func parseAdditionalGithubInfo(annotations *amTemplate.KV) *GithubInfo {
 	var ghProjectInfo GithubInfo
 

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -238,6 +238,18 @@ func (c *Client) CloseIssue(issue *github.Issue) (*github.Issue, error) {
 	return closedIssue, nil
 }
 
+// AssignIssueToProject creates a project card for the given projectId and assigns the issue
+// to the created card. If no project is found by that given ID, an error will be returned.
+func (c *Client) AssignIssueToProject(issue *github.Issue, columnId int64) (*github.ProjectCard, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	opts := github.ProjectCardOptions{ContentID: *issue.ID, ContentType: "Issue"}
+	card, _, err := c.GithubClient.Projects.CreateProjectCard(ctx, columnId, &opts)
+
+	return card, err
+}
+
 // getOrgAndRepoFromIssue reads the issue RepositoryURL and extracts the
 // owner and repo names. Issues returned by the Search API contain partial
 // records.

--- a/issues/local/local.go
+++ b/issues/local/local.go
@@ -89,3 +89,10 @@ func (c *Client) CloseIssue(issue *github.Issue) (*github.Issue, error) {
 	delete(c.issues, issue.GetTitle())
 	return issue, nil
 }
+
+// AssignIssueToProject assigns a github issue to a project, which in turn creates a project card and
+// assigns the issue to it. This local client will not implement this capability.
+func (c *Client) AssignIssueToProject(issue *github.Issue, columnId int64) (*github.ProjectCard, error) {
+	// No-op
+	return nil, nil
+}


### PR DESCRIPTION
A use case we have is that we want to provide custom labels per alert when they launch, that can be provided via annotations on the Alert Manager alert when it fires. Also, we wanted to be able to assign the issue directly to a project upon creation, also provided through annotations. This will allow flexibility to use a single instance for routing issues to different projects in the same organization.

Trying to figure out a way to cleanly test this currently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/alertmanager-github-receiver/41)
<!-- Reviewable:end -->
