### PR TITLE
add verbose flag to prevent logging authtoken

### DIFF
--- a/cmd/github_receiver/main.go
+++ b/cmd/github_receiver/main.go
@@ -47,6 +47,7 @@ var (
 	enableInMemory  = flag.Bool("enable-inmemory", false, "Perform all operations in memory, without using github API.")
 	receiverAddr    = flag.String("webhook.listen-address", ":9393", "Listen on address for new alertmanager webhook messages.")
 	alertLabel      = flag.String("alertlabel", "alert:boom:", "The default label applied to all alerts. Also used to search the repo to discover exisitng alerts.")
+	verbose         = flag.Bool("verbose", false, "Print additional log messages.")
 	extraLabels     = flagx.StringArray{}
 	titleTmplFile   = flagx.FileBytes(alerts.DefaultTitleTmpl)
 )
@@ -107,7 +108,7 @@ func mustServeWebhookReceiver(receiver *alerts.ReceiverHandler) *http.Server {
 
 func main() {
 	flag.Parse()
-	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Failed to read ArgsFromEnv")
+	rtx.Must(flagx.ArgsFromEnvWithLog(flag.CommandLine, *verbose), "Failed to read ArgsFromEnv")
 	if (*authtoken == "" && len(authtokenFile) == 0) || *githubOrg == "" || *githubRepo == "" {
 		flag.Usage()
 		osExit(1)

--- a/cmd/github_receiver/main_test.go
+++ b/cmd/github_receiver/main_test.go
@@ -64,6 +64,7 @@ func Test_main(t *testing.T) {
 		// Guarantee no port conflicts between tests of main.
 		*prometheusx.ListenAddress = ":0"
 		*receiverAddr = ":0"
+		*verbose = true
 
 		// Create template file.
 		if tt.titleTmpl != "" {


### PR DESCRIPTION
Currently all arguments get logged including the authorization token. Even if a authtokenFile is given it will print the token.
For security reasons I would suggest to only print the argument logs, if the verbose parameter is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/alertmanager-github-receiver/44)
<!-- Reviewable:end -->
