### PR TITLE
fix getOrgAndRepoFromIssue for enterprise

### DIFF
--- a/issues/issues.go
+++ b/issues/issues.go
@@ -275,10 +275,18 @@ func getOrgAndRepoFromIssue(issue *github.Issue) (string, string, error) {
 		return "", "", err
 	}
 	fields := strings.Split(u.Path, "/")
-	if len(fields) != 4 {
+	if len(fields) < 4 {
 		return "", "", fmt.Errorf("Issue has invalid RepositoryURL path values")
 	}
-	return fields[2], fields[3], nil
+
+	for i := 0; i <= len(fields); i++ {
+		if fields[i] == "repos" {
+			if i+2 == len(fields)-1 {
+				return fields[i+1], fields[i+2], nil
+			}
+		}
+	}
+	return "", "", fmt.Errorf("Issue has invalid RepositoryURL path values")
 
 }
 

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -279,7 +279,9 @@ func getOrgAndRepoFromIssue(issue *github.Issue) (string, string, error) {
 		return "", "", fmt.Errorf("Issue has invalid RepositoryURL path values")
 	}
 
-	for i := 0; i <= len(fields); i++ {
+	//this supports urls of github ("http(s)://api.github.com/repos/org/repo") and
+	//enterprise ("http(s)://hostname/api/version/repos/org/repo")
+	for i := 0; i < len(fields); i++ {
 		if fields[i] == "repos" {
 			if i+2 == len(fields)-1 {
 				return fields[i+1], fields[i+2], nil
@@ -287,7 +289,6 @@ func getOrgAndRepoFromIssue(issue *github.Issue) (string, string, error) {
 		}
 	}
 	return "", "", fmt.Errorf("Issue has invalid RepositoryURL path values")
-
 }
 
 func updateRateMetrics(api string, resp *github.Response, err error) {

--- a/issues/issues_test.go
+++ b/issues/issues_test.go
@@ -364,6 +364,15 @@ func TestClient_CloseIssue(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "error-incomplete-enterprise-url",
+			org:  "fake-org",
+			issue: &github.Issue{
+				Number:        github.Int(1),
+				RepositoryURL: github.String("https://example.github.com/api/v1/repos/fake-org"),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/issues/issues_test.go
+++ b/issues/issues_test.go
@@ -326,6 +326,18 @@ func TestClient_CloseIssue(t *testing.T) {
 			},
 		},
 		{
+			name: "successWithEnterprise",
+			org:  "fake-org",
+			issue: &github.Issue{
+				Number:        github.Int(1),
+				RepositoryURL: github.String("https://example.github.com/api/v3/repos/fake-org/fake-repo"),
+			},
+			want: &github.Issue{
+				Number:        github.Int(1),
+				RepositoryURL: github.String("https://example.github.com/api/v3/repos/fake-org/fake-repo"),
+			},
+		},
+		{
 			name:    "error-empty-repository-url",
 			org:     "fake-org",
 			issue:   &github.Issue{RepositoryURL: nil}, // Empty repostiry url.
@@ -363,7 +375,6 @@ func TestClient_CloseIssue(t *testing.T) {
 			c.GithubClient.BaseURL = setupServer()
 			defer teardownServer()
 
-			u := "https://api.github.com/repos/fake-org/fake-repo"
 			testMux.HandleFunc("/repos/fake-org/fake-repo/issues/1", func(w http.ResponseWriter, r *http.Request) {
 				// TODO: add rate limit headers in response to trigger a RateLimitError.
 				if tt.wantErr {
@@ -376,7 +387,7 @@ func TestClient_CloseIssue(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				fmt.Fprintf(w, `{"number":1, "repository_url":"%s"}`, u)
+				fmt.Fprintf(w, `{"number":1, "repository_url":"%s"}`, tt.issue.GetRepositoryURL())
 			})
 
 			got, err := c.CloseIssue(tt.issue)


### PR DESCRIPTION
Found a bug for enterprise in getOrgAndRepoFromIssue(), which occur when labels are used. It occurs because the enterprise URL path contains /api/v3/ at the beginning.
I add some logic which reads only the two fields after the first occurred "repos"/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/alertmanager-github-receiver/45)
<!-- Reviewable:end -->
