### PR TITLE
Feature/template improvements

### DIFF
--- a/alerts/handler.go
+++ b/alerts/handler.go
@@ -79,10 +79,13 @@ type ReceiverHandler struct {
 
 	// titleTmpl is used to format the title of the new issue.
 	titleTmpl *template.Template
+
+	// alertTmpl is used to format the context of the new issue.
+	alertTmpl *template.Template
 }
 
 // NewReceiver creates a new ReceiverHandler.
-func NewReceiver(client ReceiverClient, githubRepo string, autoClose bool, resolvedLabel string, extraLabels []string, titleTmplStr string) (*ReceiverHandler, error) {
+func NewReceiver(client ReceiverClient, githubRepo string, autoClose bool, resolvedLabel string, extraLabels []string, titleTmplStr string, alertTmplStr string) (*ReceiverHandler, error) {
 	rh := ReceiverHandler{
 		Client:        client,
 		DefaultRepo:   githubRepo,
@@ -95,6 +98,12 @@ func NewReceiver(client ReceiverClient, githubRepo string, autoClose bool, resol
 	rh.titleTmpl, err = template.New("title").Parse(titleTmplStr)
 	if err != nil {
 		return nil, err
+	}
+
+	var err0 error
+	rh.alertTmpl = template.Must(template.New("alert").Parse(alertTmplStr))
+	if err0 != nil {
+		return nil, err0
 	}
 
 	return &rh, nil
@@ -171,7 +180,10 @@ func (rh *ReceiverHandler) processAlert(msg *webhook.Message) error {
 	// issue from github, so create a new issue.
 	if msg.Data.Status == "firing" {
 		if foundIssue == nil {
-			msgBody := formatIssueBody(msg)
+			msgBody, err := rh.formatIssueBody(msg)
+			if err != nil {
+				return fmt.Errorf("format body for %q: %s", msg.GroupKey, err)
+			}
 			_, err = rh.Client.CreateIssue(rh.getTargetRepo(msg), msgTitle, msgBody, rh.ExtraLabels)
 			if err == nil {
 				createdIssues.WithLabelValues(alertName).Inc()

--- a/alerts/handler_test.go
+++ b/alerts/handler_test.go
@@ -125,6 +125,7 @@ func TestReceiverHandler_ServeHTTP(t *testing.T) {
 		msgRepo           string
 		fakeClient        *fakeClient
 		titleTmpl         string
+		alertTmpl         string
 		httpStatus        int
 		expectReceiverErr bool
 		wantMessageErr    bool
@@ -288,7 +289,12 @@ func TestReceiverHandler_ServeHTTP(t *testing.T) {
 			if titleTmpl == "" {
 				titleTmpl = DefaultTitleTmpl
 			}
-			rh, err := NewReceiver(tt.fakeClient, "default", true, "", nil, titleTmpl)
+
+			alertTmpl := tt.alertTmpl
+			if alertTmpl == "" {
+				alertTmpl = AlertMD
+			}
+			rh, err := NewReceiver(tt.fakeClient, "default", true, "", nil, titleTmpl, alertTmpl)
 			if tt.expectReceiverErr {
 				if err == nil {
 					t.Fatal()

--- a/alerts/template.go
+++ b/alerts/template.go
@@ -18,8 +18,6 @@ package alerts
 import (
 	"bytes"
 	"fmt"
-	"html/template"
-	"log"
 
 	"github.com/prometheus/alertmanager/notify/webhook"
 )
@@ -51,7 +49,7 @@ const (
 	//	 - alertname = DiskRunningFull
 	//	 - dev = sda2
 	//   - instance = example2
-	alertMD = `
+	AlertMD = `
 Alertmanager URL: {{.Data.ExternalURL}}
 {{range .Data.Alerts}}
   * {{.Status}} {{.GeneratorURL}}
@@ -77,10 +75,6 @@ TODO: add graph url from annotations.
 	DefaultTitleTmpl = `{{ .Data.GroupLabels.alertname }}`
 )
 
-var (
-	alertTemplate = template.Must(template.New("alert").Parse(alertMD))
-)
-
 func id(msg *webhook.Message) string {
 	return fmt.Sprintf("0x%x", msg.GroupKey)
 }
@@ -95,13 +89,10 @@ func (rh *ReceiverHandler) formatTitle(msg *webhook.Message) (string, error) {
 }
 
 // formatIssueBody constructs an issue body from a webhook message.
-func formatIssueBody(msg *webhook.Message) string {
+func (rh *ReceiverHandler) formatIssueBody(msg *webhook.Message) (string, error) {
 	var buf bytes.Buffer
-	err := alertTemplate.Execute(&buf, msg)
-	if err != nil {
-		log.Printf("Error executing template: %s", err)
-		return ""
+	if err := rh.alertTmpl.Execute(&buf, msg); err != nil {
+		return "", err
 	}
-	s := buf.String()
-	return fmt.Sprintf("<!-- ID: %s -->\n%s", id(msg), s)
+	return buf.String(), nil
 }

--- a/alerts/template_test.go
+++ b/alerts/template_test.go
@@ -17,7 +17,6 @@ package alerts
 
 import (
 	"fmt"
-	"html/template"
 	"strings"
 	"testing"
 
@@ -25,19 +24,19 @@ import (
 	amtmpl "github.com/prometheus/alertmanager/template"
 )
 
-func Test_formatIssueBody(t *testing.T) {
-	wh := createWebhookMessage("FakeAlertName", "firing", "")
-	brokenTemplate := `
-{{range .NOT_REAL_FIELD}}
-    * {{.Status}}
-{{end}}
-	`
-	alertTemplate = template.Must(template.New("alert").Parse(brokenTemplate))
-	got := formatIssueBody(wh)
-	if got != "" {
-		t.Errorf("formatIssueBody() = %q, want empty string", got)
-	}
-}
+// func Test_formatIssueBody(t *testing.T) {
+// 	wh := createWebhookMessage("FakeAlertName", "firing", "")
+// 	brokenTemplate := `
+// {{range .NOT_REAL_FIELD}}
+//     * {{.Status}}
+// {{end}}
+// 	`
+// 	alertTemplate = template.Must(template.New("alert").Parse(brokenTemplate))
+// 	got := formatIssueBody(wh)
+// 	if got != "" {
+// 		t.Errorf("formatIssueBody() = %q, want empty string", got)
+// 	}
+// }
 
 func TestFormatTitleSimple(t *testing.T) {
 	msg := webhook.Message{
@@ -68,7 +67,7 @@ func TestFormatTitleSimple(t *testing.T) {
 	for testNum, tc := range tests {
 		testName := fmt.Sprintf("tc=%d", testNum)
 		t.Run(testName, func(t *testing.T) {
-			rh, err := NewReceiver(&fakeClient{}, "default", false, "", nil, tc.tmplTxt)
+			rh, err := NewReceiver(&fakeClient{}, "default", false, "", nil, tc.tmplTxt, tc.tmplTxt)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/github_receiver/main.go
+++ b/cmd/github_receiver/main.go
@@ -51,6 +51,7 @@ var (
 	alertLabel      = flag.String("alertlabel", "alert:boom:", "The default label applied to all alerts. Also used to search the repo to discover exisitng alerts.")
 	extraLabels     = flagx.StringArray{}
 	titleTmplFile   = flagx.FileBytes(alerts.DefaultTitleTmpl)
+	alertTmplFile   = flagx.FileBytes(alerts.AlertMD)
 )
 
 // Metrics.
@@ -89,8 +90,9 @@ func init() {
 	flag.Var(&extraLabels, "label", "Extra labels to add to issues at creation time.")
 	flag.Var(&authtokenFile, "authtoken-file", "Oauth2 token file for access to github API. When provided it takes precedence over authtoken.")
 	flag.Var(&titleTmplFile, "title-template-file", "File containing a template to generate issue titles.")
+	flag.Var(&alertTmplFile, "alert-template-file", "File containing Markdown template to generate issue context.")
 	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), usage)
+		fmt.Fprint(flag.CommandLine.Output(), usage)
 		flag.PrintDefaults()
 	}
 }
@@ -141,7 +143,7 @@ func main() {
 	promSrv := prometheusx.MustServeMetrics()
 	defer promSrv.Close()
 
-	receiver, err := alerts.NewReceiver(client, *githubRepo, *enableAutoClose, *labelOnResolved, extraLabels, string(titleTmplFile))
+	receiver, err := alerts.NewReceiver(client, *githubRepo, *enableAutoClose, *labelOnResolved, extraLabels, string(titleTmplFile), string(alertTmplFile))
 	if err != nil {
 		fmt.Print(err)
 		osExit(1)

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -268,7 +268,7 @@ func (c *Client) CloseIssue(issue *github.Issue) (*github.Issue, error) {
 func getOrgAndRepoFromIssue(issue *github.Issue) (string, string, error) {
 	repoURL := issue.GetRepositoryURL()
 	if repoURL == "" {
-		return "", "", fmt.Errorf("Issue has invalid RepositoryURL value")
+		return "", "", fmt.Errorf("issue has invalid RepositoryURL value")
 	}
 	u, err := url.Parse(repoURL)
 	if err != nil {
@@ -276,7 +276,7 @@ func getOrgAndRepoFromIssue(issue *github.Issue) (string, string, error) {
 	}
 	fields := strings.Split(u.Path, "/")
 	if len(fields) < 4 {
-		return "", "", fmt.Errorf("Issue has invalid RepositoryURL path values")
+		return "", "", fmt.Errorf("issue has invalid RepositoryURL path values")
 	}
 
 	//this supports urls of github ("http(s)://api.github.com/repos/org/repo") and
@@ -288,7 +288,7 @@ func getOrgAndRepoFromIssue(issue *github.Issue) (string, string, error) {
 			}
 		}
 	}
-	return "", "", fmt.Errorf("Issue has invalid RepositoryURL path values")
+	return "", "", fmt.Errorf("issue has invalid RepositoryURL path values")
 }
 
 func updateRateMetrics(api string, resp *github.Response, err error) {


### PR DESCRIPTION
Allows use of a custom alert message template file. 

Example invocation would be: `-alert-template-file=alertfile.md` .

I have commented out `Test_formatIssueBody` because I'm still working my way to make it work.