### PR TITLE
Feature/make docker image smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ADD . ./
 ENV CGO_ENABLED 0
 RUN go build \
     -v \
-    -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" \
+    -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h) -w -s" \
     ./cmd/github_receiver
 
 FROM alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,12 @@ RUN go mod download
 ADD . ./
 
 # TODO(soltesz): Use vgo for dependencies.
-ENV CGO_ENABLED 0
-RUN go build \
+RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux \
+    go build \
     -v \
-    -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h) -w -s" \
+    -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h) -w -s -extldflags '-static'" \
     ./cmd/github_receiver
 
-FROM alpine
-RUN apk add --no-cache ca-certificates && \
-    update-ca-certificates
-WORKDIR /
+FROM gcr.io/distroless/static
 COPY --from=builder /go/src/github.com/m-lab/alertmanager-github-receiver/github_receiver ./
 ENTRYPOINT ["/github_receiver"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 as builder
+FROM golang:1.17-alpine as builder
 
 WORKDIR /go/src/github.com/m-lab/alertmanager-github-receiver
 ADD go.mod go.sum ./
@@ -8,9 +8,9 @@ ADD . ./
 # TODO(soltesz): Use vgo for dependencies.
 ENV CGO_ENABLED 0
 RUN go build \
-       -v \
-      -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" \
-       ./cmd/github_receiver
+    -v \
+    -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" \
+    ./cmd/github_receiver
 
 FROM alpine
 RUN apk add --no-cache ca-certificates && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux \
     -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h) -w -s -extldflags '-static'" \
     ./cmd/github_receiver
 
+# See also: https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md
 FROM gcr.io/distroless/static
+
 COPY --from=builder /go/src/github.com/m-lab/alertmanager-github-receiver/github_receiver ./
 ENTRYPOINT ["/github_receiver"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ADD go.mod go.sum ./
 RUN go mod download
 ADD . ./
 
-# TODO(soltesz): Use vgo for dependencies.
 RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux \
     go build \
     -v \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ADD . ./
 RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux \
     go build \
     -v \
-    -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h) -w -s -extldflags '-static'" \
+    -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h) -w -s" \
     ./cmd/github_receiver
 
 # See also: https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md


### PR DESCRIPTION
Changes:

- updated Go version to 1.17
- used distroless static image 

Size reduction ~45% (43.49%) from 28.51MB to 16.11MB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/alertmanager-github-receiver/55)
<!-- Reviewable:end -->
