### PR TITLE
Update unit test for formatTitle

### DIFF
--- a/alerts/template_test.go
+++ b/alerts/template_test.go
@@ -16,9 +16,7 @@
 package alerts
 
 import (
-	"fmt"
 	"html/template"
-	"strings"
 	"testing"
 
 	"github.com/prometheus/alertmanager/notify/webhook"
@@ -39,7 +37,7 @@ func Test_formatIssueBody(t *testing.T) {
 	}
 }
 
-func TestFormatTitleSimple(t *testing.T) {
+func TestReceiverHandler_formatTitle(t *testing.T) {
 	msg := webhook.Message{
 		Data: &amtmpl.Data{
 			Status: "firing",
@@ -54,41 +52,46 @@ func TestFormatTitleSimple(t *testing.T) {
 		},
 	}
 	tests := []struct {
-		tmplTxt      string
-		expectErrTxt string
-		expectOutput string
+		name     string
+		template string
+		want     string
+		wantErr  bool
 	}{
-		{"foo", "", "foo"},
-		{"{{ .Data.Status }}", "", "firing"},
-		{"{{ .Status }}", "", "firing"},
-		{"{{ range .Alerts }}{{ .Annotations.env }} {{ end }}", "", "prod stage "},
-		{"{{ .Foo }}", "can't evaluate field Foo", ""},
+		{
+			name:     "success",
+			template: "foo",
+			want:     "foo",
+		},
+		{
+			name:     "success-firing",
+			template: "{{ .Data.Status }}",
+			want:     "firing",
+		},
+		{
+			name:     "success-projects",
+			template: "{{ range .Alerts }}{{ .Annotations.env }} {{ end }}",
+			want:     "prod stage ",
+		},
+		{
+			name:     "error-bad-template",
+			template: "{{ .Foo }}",
+			wantErr:  true,
+		},
 	}
-
-	for testNum, tc := range tests {
-		testName := fmt.Sprintf("tc=%d", testNum)
-		t.Run(testName, func(t *testing.T) {
-			rh, err := NewReceiver(&fakeClient{}, "default", false, "", nil, tc.tmplTxt)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rh, err := NewReceiver(&fakeClient{}, "default", false, "", nil, tt.template)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			title, err := rh.formatTitle(&msg)
-			if tc.expectErrTxt == "" && err != nil {
-				t.Error(err)
+			got, err := rh.formatTitle(&msg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReceiverHandler.formatTitle() error = %v, wantErr %v", err, tt.wantErr)
+				return
 			}
-			if tc.expectErrTxt != "" {
-				if err == nil {
-					t.Error()
-				} else if !strings.Contains(err.Error(), tc.expectErrTxt) {
-					t.Error(err.Error())
-				}
-			}
-			if tc.expectOutput == "" && title != "" {
-				t.Error(title)
-			}
-			if !strings.Contains(title, tc.expectOutput) {
-				t.Error(title)
+			if got != tt.want {
+				t.Errorf("ReceiverHandler.formatTitle() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/alerts/template_test.go
+++ b/alerts/template_test.go
@@ -58,17 +58,17 @@ func TestReceiverHandler_formatTitle(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:     "success",
+			name:     "success-simple",
 			template: "foo",
 			want:     "foo",
 		},
 		{
-			name:     "success-firing",
+			name:     "success-template-simple",
 			template: "{{ .Data.Status }}",
 			want:     "firing",
 		},
 		{
-			name:     "success-projects",
+			name:     "success-template-complex",
 			template: "{{ range .Alerts }}{{ .Annotations.env }} {{ end }}",
 			want:     "prod stage ",
 		},

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
-	golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 // indirect
+	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/protobuf v1.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -417,6 +417,8 @@ golang.org/x/sys v0.0.0-20200409092240-59c9f1ba88fa/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
While responding to https://github.com/m-lab/alertmanager-github-receiver/pull/54 I found the current unit test format for a `formatTitle` function to be very non-standard. This change updates the unit test to follow more contemporary standards.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/alertmanager-github-receiver/57)
<!-- Reviewable:end -->
